### PR TITLE
add metadata and generate boilerplate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,65 @@
+os: linux
+dist: bionic
+language: shell
+
+.opam: &OPAM
+  language: shell
+  services: docker
+  install: |
+    # Prepare the COQ container
+    docker pull ${COQ_IMAGE}
+    docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/coq/${PACKAGE} -w /home/coq/${PACKAGE} ${COQ_IMAGE}
+    docker exec COQ /bin/bash --login -c "
+      # This bash script is double-quoted to interpolate Travis CI env vars:
+      echo \"Build triggered by ${TRAVIS_EVENT_TYPE}\"
+      export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+      set -ex  # -e = exit on failure; -x = trace for debug
+      opam update -y
+      opam pin add ${PACKAGE} . -y -n -k path
+      opam install ${PACKAGE} -y -j ${NJOBS} --deps-only
+      opam config list
+      opam repo list
+      opam list
+      "
+  script:
+  - echo -e "${ANSI_YELLOW}Building ${PACKAGE}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
+  - |
+    docker exec COQ /bin/bash --login -c "
+      export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+      set -ex
+      sudo chown -R coq:coq /home/coq/${PACKAGE}
+      opam install ${PACKAGE} -v -y -j ${NJOBS}
+      "
+  - docker stop COQ  # optional
+  - echo -en 'travis_fold:end:script\\r'
+
+.nix: &NIX
+  language: nix
+  install:
+  # for cachix we need travis to be a trusted nix user
+  - echo "trusted-users = $USER" | sudo tee -a /etc/nix/nix.conf
+  - sudo systemctl restart nix-daemon
+  script:
+  - nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:5QW/wwEnD+l2jvN6QRbRRsa4hBHG3QiQQ26cxu1F5tI="
+
+jobs:
+  include:
+
+  # Test supported versions of Coq via Nix
+  - env:
+    - COQ=8.12
+    <<: *NIX
+  - env:
+    - COQ=8.11
+    <<: *NIX
+  - env:
+    - COQ=8.10
+    <<: *NIX
+
+  # Test supported versions of Coq via OPAM
+  - env:
+    - COQ_IMAGE=coqorg/coq:dev
+    - PACKAGE=coq-coq100.dev
+    - NJOBS=2
+    <<: *OPAM
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,55 @@
 # 100 famous theorems proved using Coq
 
-[Freek Wiedijk's webpage](http://www.cs.ru.nl/~freek/100/) lists [100 famous theorems](http://pirate.shu.edu/~kahlnath/Top100.html) and how many of those have been formalised using proof assistants.  This repository keeps track of the statements that have been proved using the [Coq proof assistant](https://coq.inria.fr/).
+[![Travis][travis-shield]][travis-link]
+[![Contributing][contributing-shield]][contributing-link]
+[![Code of Conduct][conduct-shield]][conduct-link]
+[![Zulip][zulip-shield]][zulip-link]
+
+[travis-shield]: https://travis-ci.com/coq-community/coq100.svg?branch=master
+[travis-link]: https://travis-ci.com/coq-community/coq100/builds
+
+[contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg
+[contributing-link]: https://github.com/coq-community/manifesto/blob/master/CONTRIBUTING.md
+
+[conduct-shield]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-%23f15a24.svg
+[conduct-link]: https://github.com/coq-community/manifesto/blob/master/CODE_OF_CONDUCT.md
+
+[zulip-shield]: https://img.shields.io/badge/chat-on%20zulip-%23c1272d.svg
+[zulip-link]: https://coq.zulipchat.com/#narrow/stream/237663-coq-community-devs.20.26.20users
+
+
+
+[Freek Wiedijk's webpage](http://www.cs.ru.nl/~freek/100/) lists
+[100 famous theorems](http://pirate.shu.edu/~kahlnath/Top100.html)
+and how many of those have been formalised using proof assistants.
+This repository keeps track of the statements that have been proved
+using the [Coq proof assistant](https://coq.inria.fr/).
 
 You can see the list on [this webpage](https://madiot.fr/coq100).
+
+## Meta
+
+- Author(s):
+  - Jean-Marie Madiot
+  - Frédéric Chardard
+- Coq-community maintainer(s):
+  - Jean-Marie Madiot ([**@jmadiot**](https://github.com/jmadiot))
+- License: [MIT License](LICENSE)
+- Compatible Coq versions: 8.10 or later
+- Additional dependencies:
+  - [Coquelicot 3.1.0 or later](http://coquelicot.saclay.inria.fr)
+- Coq namespace: `Coq100`
+- Related publication(s): none
+
+## Building instructions
+
+To build all theorems that are hosted in this repository,
+run the following commands:
+
+``` shell
+git clone https://github.com/coq-community/coq100
+cd coq100
+make   # or make -j <number-of-cores-on-your-machine>
+```
+
+

--- a/coq-coq100.opam
+++ b/coq-coq100.opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "palmskog@gmail.com"
+version: "dev"
+
+homepage: "https://github.com/coq-community/coq100"
+dev-repo: "git+https://github.com/coq-community/coq100.git"
+bug-reports: "https://github.com/coq-community/coq100/issues"
+license: "MIT"
+
+synopsis: "Coq theorems from the list of 100 famous theorems"
+description: """
+[Freek Wiedijk's webpage](http://www.cs.ru.nl/~freek/100/) lists
+[100 famous theorems](http://pirate.shu.edu/~kahlnath/Top100.html)
+and how many of those have been formalised using proof assistants.
+This repository keeps track of the statements that have been proved
+using the [Coq proof assistant](https://coq.inria.fr/).
+
+You can see the list on [this webpage](https://madiot.fr/coq100)."""
+
+build: [make "-j%{jobs}%" ]
+install: [make "install"]
+depends: [
+  "coq" {(>= "8.10" & < "8.13~") | (= "dev")}
+  "coq-coquelicot" {>= "3.1.0"}
+]
+
+tags: [
+  "category:Mathematics/Algebra"
+  "keyword:famous theorems"
+  "logpath:Coq100"
+]
+authors: [
+  "Jean-Marie Madiot"
+  "Frédéric Chardard"
+]

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,26 @@
+{ pkgs ? (import <nixpkgs> {}), coq-version-or-url, shell ? false }:
+
+let
+  coq-version-parts = builtins.match "([0-9]+).([0-9]+)" coq-version-or-url;
+  coqPackages =
+    if coq-version-parts == null then
+      pkgs.mkCoqPackages (import (fetchTarball coq-version-or-url) {})
+    else
+      pkgs."coqPackages_${builtins.concatStringsSep "_" coq-version-parts}";
+in
+
+with coqPackages;
+
+pkgs.stdenv.mkDerivation {
+
+  name = "coq100";
+
+  propagatedBuildInputs = [
+    coq
+    coquelicot
+  ];
+
+  src = if shell then null else ./.;
+
+  installFlags = "COQMF_COQLIB=$(out)/lib/coq/${coq.coq-version}/";
+}

--- a/dune
+++ b/dune
@@ -1,0 +1,4 @@
+(coq.theory
+ (name Coq100)
+ (package coq-coq100)
+ (synopsis "Coq theorems from the list of 100 famous theorems"))

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,3 @@
+(lang dune 2.5)
+(using coq 0.2)
+(name coq100)

--- a/meta.yml
+++ b/meta.yml
@@ -1,0 +1,74 @@
+---
+fullname: 100 famous theorems proved using Coq
+shortname: coq100
+organization: coq-community
+community: true
+travis: true
+
+synopsis: Coq theorems from the list of 100 famous theorems
+
+description: |-
+  [Freek Wiedijk's webpage](http://www.cs.ru.nl/~freek/100/) lists
+  [100 famous theorems](http://pirate.shu.edu/~kahlnath/Top100.html)
+  and how many of those have been formalised using proof assistants.
+  This repository keeps track of the statements that have been proved
+  using the [Coq proof assistant](https://coq.inria.fr/).
+
+  You can see the list on [this webpage](https://madiot.fr/coq100).
+
+authors:
+- name: Jean-Marie Madiot
+- name: Frédéric Chardard
+
+maintainers:
+- name: Jean-Marie Madiot
+  nickname: jmadiot
+
+opam-file-maintainer: palmskog@gmail.com
+
+opam-file-version: dev
+
+license:
+  fullname: MIT License
+  identifier: MIT
+
+supported_coq_versions:
+  text: 8.10 or later
+  opam: '{(>= "8.10" & < "8.13~") | (= "dev")}'
+
+tested_coq_nix_versions:
+- version_or_url: '8.12'
+- version_or_url: '8.11'
+- version_or_url: '8.10'
+
+tested_coq_opam_versions:
+- version: dev
+
+dependencies:
+- opam:
+    name: coq-coquelicot
+    version: '{>= "3.1.0"}'
+  nix: coquelicot
+  description: |-
+    [Coquelicot 3.1.0 or later](http://coquelicot.saclay.inria.fr)
+
+namespace: Coq100
+
+build: |-
+ ## Building instructions
+
+ To build all theorems that are hosted in this repository,
+ run the following commands:
+
+ ``` shell
+ git clone https://github.com/coq-community/coq100
+ cd coq100
+ make   # or make -j <number-of-cores-on-your-machine>
+ ```
+
+keywords:
+- name: famous theorems
+
+categories:
+- name: Mathematics/Algebra
+---


### PR DESCRIPTION
This uses our [templates](https://github.com/coq-community/templates) to generate boilerplate for CI and documentation. Please take a look at the generated README.md (some info could be removed, at the cost having to re-remove it when `README.md` is generated from the template in the future).