### PR TITLE
fix references to qarith-stern-brocot and bertrand

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,9 +44,9 @@
 <div>
 <p class='statementinfo'>
 <strong class='author'>many versions</strong>
-(e.g. <a class='location' href="http://www.lix.polytechnique.fr/coq/distrib/8.2/contribs/QArithSternBrocot.sqrt2.html">one in contribs/QArithSternBrocot/sqrt2</a>):
+(e.g., <a class='location' href="https://github.com/coq-community/qarith-stern-brocot/blob/master/theories/sqrt2.v">one in qarith-stern-brocot/sqrt2</a>):
 <pre class='comment'></pre>
-<pre class='statement'>Theorem sqrt2_not_rational : forall p q, q <> 0 -> p * p <> q * q * 2.</pre>
+<pre class='statement'>Theorem sqrt2_not_rational : forall p q : nat, q <> 0 -> p * p = 2 * (q * q) -> False.</pre>
 </p>
 </div>
 
@@ -66,16 +66,18 @@
 <div>
 <p class='statementinfo'>
 <strong class='author'>Milad Niqui</strong>
-(in <a class='location' href="http://www.lix.polytechnique.fr/coq/distrib/8.2/contribs/QArithSternBrocot.Q_denumerable.html">contribs/QArithSternBrocot/Q_denumerable</a>):
+(in <a class='location' href="https://github.com/coq-community/qarith-stern-brocot/blob/master/theories/Q_denumerable.v">qarith-stern-brocot/Q_denumerable</a>):
 <pre class='comment'></pre>
-<pre class='statement'>Theorem Q_is_denumerable: same_cardinality Q nat.
+<pre class='statement'>Theorem Q_is_denumerable: is_denumerable Q.
 
 Definition same_cardinality (A:Set) (B:Set) :=
   { f : A -> B &
   { g : B -> A |
     forall b,(compose _ _ _ f g) b = (identity B) b /\
     forall a,(compose _ _ _ g f) a = (identity A) a
-  }}.</pre>
+  }}.
+
+Definition is_denumerable A := same_cardinality A nat.</pre>
 </p>
 <strong class='author'>Daniel Schepler</strong>
 (in <a class='location' href="https://github.com/coq-community/zorns-lemma/blob/master/CountableTypes.v">coq-community/zorns-lemma/CountableTypes</a>):
@@ -1566,10 +1568,9 @@ Lemma mul_adj_mx : forall n (A : 'M[R]_n), \adj A *m A = (\det A)%:M.</pre>
 <div>
 <p class='statementinfo'>
 <strong class='author'>Laurent Théry</strong>
-(in <a class='location' href="http://www.lix.polytechnique.fr/coq/distrib/8.2/contribs/Bertrand.Bertrand.html">contribs/Bertrand/Bertrand</a>):
+(in <a class='location' href="https://github.com/coq-community/bertrand/blob/master/Bertrand.v">bertrand/Bertrand</a>):
 <pre class='comment'></pre>
-<pre class='statement'>Theorem Bertrand :
- forall n : nat, 2 <= n -> exists p : nat, prime p /\ n < p /\ p < 2 * n.</pre>
+<pre class='statement'>Theorem Bertrand : forall n : nat, 2 <= n -> exists p : nat, prime p /\ n < p /\ p < 2 * n.</pre>
 </p>
 </div>
 


### PR DESCRIPTION
I follow the general rule that statements should not be made semantically different than the original statement, but space formatting changes are fine.