### PR TITLE
Add formalization of problem 88

### DIFF
--- a/index.html
+++ b/index.html
@@ -1419,9 +1419,16 @@ Lemma l13_18 : forall A B C A' B' C' O,
 </div>
 
 
-<h3 id='88' class='notformalizedyet'><a href='http://www.cs.ru.nl/~freek/100/#88'>88. Derangements Formula</a></h3>
+<h3 id='88' class='formalized'><a href='http://www.cs.ru.nl/~freek/100/#88'>88. Derangements Formula</a></h3>
 <div>
-<span class="unknown">No known Coq formalization</span>
+<p class='statementinfo'>
+<strong class='author'>Fabian Wolff</strong>
+(<a class='location' href="https://github.com/FabianWolff/coq-derangements-formula">on GitHub</a>):
+<pre class='comment'></pre>
+<pre class='statement'>Theorem drm_formula: forall n, n > 0 ->
+    round ((INR (fact n)) * (exp (-1))) = Some (Z.of_nat (length (drm_construct n))).
+</pre>
+</p>
 </div>
 
 


### PR DESCRIPTION
I have recently completed a [formalization](https://github.com/FabianWolff/coq-derangements-formula) of problem 88 (the derangements formula), so it could be added to the list of formalized problems.

I am by no means an expert in Coq, which is why my proof is most likely inefficient and/or ugly in various respects. But it verifies; here is the formulation of the main theorem:

```Coq
Theorem drm_formula: forall n, n > 0 ->
    round ((INR (fact n)) * (exp (-1))) = Some (Z.of_nat (length (drm_construct n))).
```