### PR TITLE
add compatibility with Coq 8.13, update CI boilerplate

### DIFF
--- a/.github/workflows/coq-ci.yml
+++ b/.github/workflows/coq-ci.yml
@@ -1,4 +1,6 @@
-name: CI
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+name: Docker CI
 
 on:
   push:
@@ -16,6 +18,7 @@ jobs:
       matrix:
         image:
           - 'coqorg/coq:dev'
+          - 'coqorg/coq:8.13'
           - 'coqorg/coq:8.12'
           - 'coqorg/coq:8.11'
           - 'coqorg/coq:8.10'

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
+<!---
+This file was generated from `meta.yml`, please do not edit manually.
+Follow the instructions on https://github.com/coq-community/templates to regenerate.
+--->
 # 100 famous theorems proved using Coq
 
-[![CI][action-shield]][action-link]
+[![Docker CI][docker-action-shield]][docker-action-link]
 [![Contributing][contributing-shield]][contributing-link]
 [![Code of Conduct][conduct-shield]][conduct-link]
 [![Zulip][zulip-shield]][zulip-link]
 
-[action-shield]: https://github.com/coq-community/coq100/workflows/CI/badge.svg?branch=master
-[action-link]: https://github.com/coq-community/coq100/actions?query=workflow%3ACI
+[docker-action-shield]: https://github.com/coq-community/coq100/workflows/Docker%20CI/badge.svg?branch=master
+[docker-action-link]: https://github.com/coq-community/coq100/actions?query=workflow:"Docker%20CI"
 
 [contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg
 [contributing-link]: https://github.com/coq-community/manifesto/blob/master/CONTRIBUTING.md

--- a/coq-coq100.opam
+++ b/coq-coq100.opam
@@ -1,3 +1,6 @@
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+
 opam-version: "2.0"
 maintainer: "palmskog@gmail.com"
 version: "dev"
@@ -20,7 +23,7 @@ You can see the list on [this webpage](https://madiot.fr/coq100)."""
 build: [make "-j%{jobs}%" ]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.10" & < "8.13~") | (= "dev")}
+  "coq" {(>= "8.10" & < "8.14~") | (= "dev")}
   "coq-coquelicot" {>= "3.1.0"}
 ]
 

--- a/meta.yml
+++ b/meta.yml
@@ -34,10 +34,11 @@ license:
 
 supported_coq_versions:
   text: 8.10 or later
-  opam: '{(>= "8.10" & < "8.13~") | (= "dev")}'
+  opam: '{(>= "8.10" & < "8.14~") | (= "dev")}'
 
 tested_coq_opam_versions:
 - version: dev
+- version: '8.13'
 - version: '8.12'
 - version: '8.11'
 - version: '8.10'


### PR DESCRIPTION
Coq 8.13.0 is out soon, so it should be allowed in opam and tested in CI. I also update the usual boilerplate.