### PR TITLE
update CI with Coq 8.15 and 8.16, only use lower bound for Coq

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -18,6 +18,8 @@ jobs:
       matrix:
         image:
           - 'coqorg/coq:dev'
+          - 'coqorg/coq:8.16'
+          - 'coqorg/coq:8.15'
           - 'coqorg/coq:8.14'
           - 'coqorg/coq:8.13'
           - 'coqorg/coq:8.12'
@@ -25,11 +27,12 @@ jobs:
           - 'coqorg/coq:8.10'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: coq-community/docker-coq-action@v1
         with:
           opam_file: 'coq-coq-100-theorems.opam'
           custom_image: ${{ matrix.image }}
+
 
 # See also:
 # https://github.com/coq-community/docker-coq-action#readme

--- a/coq-coq-100-theorems.opam
+++ b/coq-coq-100-theorems.opam
@@ -23,7 +23,7 @@ You can see the list on [this webpage](https://madiot.fr/coq100)."""
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.10" & < "8.16~") | (= "dev")}
+  "coq" {>= "8.10"}
   "coq-coquelicot" {>= "3.1.0"}
 ]
 

--- a/meta.yml
+++ b/meta.yml
@@ -34,10 +34,12 @@ license:
 
 supported_coq_versions:
   text: 8.10 or later
-  opam: '{(>= "8.10" & < "8.16~") | (= "dev")}'
+  opam: '{>= "8.10"}'
 
 tested_coq_opam_versions:
 - version: dev
+- version: '8.16'
+- version: '8.15'
 - version: '8.14'
 - version: '8.13'
 - version: '8.12'


### PR DESCRIPTION
Since this project doesn't do releases, easiest to just have a lower bound for the Coq version in the opam package.